### PR TITLE
fix check-pr script by removing cd

### DIFF
--- a/check-pr.sh
+++ b/check-pr.sh
@@ -1,8 +1,4 @@
 #! /usr/bin/env bash
-
-# Make this script independent of where it's called
-cd "$(dirname "${BASH_SOURCE[0]}")"/../..
-
 set -eu
 
 echo "--- Running 'pr-auditor'"


### PR DESCRIPTION
Current pr-auditor is failing becuase it tries to cd into a path that doesn't exist

see https://sourcegraph.sentry.io/issues/4837804652/?notification_uuid=6dd0e8a5-24d0-4073-9fa8-b42b2bbc6d5d&project=4506416197992448&referrer=regression_activity-slack for failure

### Test plan
tested locally