### PR TITLE
Added flag to allow disabling reviews for a single user

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ go run . \
 
 Each check that PR auditor performs can be opted out of a repository level if they are inappropriate for your use cases. Simply set the relevant environment variable in your GitHub Action to a truthy value like `True` or `true`. By default all checks are enabled.
 
-| Environment Variable | Check Description                                                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| SKIP_CHECK_TEST_PLAN | Allows PRs to not include the Test Plan section. Useful for repositories which do not include source code (such as documentation repos). |
-| SKIP_CHECK_REVIEWS   | Allows PRs to be merged without requiring reviews. Useful for repositories which are entirely automated (such as infrastructure code).   |
+| Environment Variable         | Check Description                                                                                                                                                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SKIP_CHECK_TEST_PLAN         | Allows PRs to not include the Test Plan section. Useful for repositories which do not include source code (such as documentation repos).                                                                               |
+| SKIP_CHECK_REVIEWS           | Allows PRs to be merged without requiring reviews. Useful for repositories which are entirely automated (such as infrastructure code).                                                                                 |
+| SKIP_CHECK_REVIEWS_FOR_USERS | Allows PRs to be merged without requiring reviews for the specified users. Useful for repositories which have a clear owner(s). Format is CSV of GitHub handles. _Note: This has no effect if SKIP_CHECK_REVIEWS=true_ |
 
 ## Deployment
 

--- a/check-pr.sh
+++ b/check-pr.sh
@@ -7,4 +7,5 @@ go run . \
   -github.token="$GITHUB_TOKEN" \
   -github.run-url="$GITHUB_RUN_URL" \
   -skip-check-test-plan="${SKIP_CHECK_TEST_PLAN:-False}" \
-  -skip-check-review="${SKIP_CHECK_REVIEWS:-False}"
+  -skip-check-review="${SKIP_CHECK_REVIEWS:-False}" \
+  -skip-check-review-for-users="${SKIP_CHECK_REVIEWS_FOR_USERS}"

--- a/check-pr.sh
+++ b/check-pr.sh
@@ -8,4 +8,4 @@ go run . \
   -github.run-url="$GITHUB_RUN_URL" \
   -skip-check-test-plan="${SKIP_CHECK_TEST_PLAN:-False}" \
   -skip-check-review="${SKIP_CHECK_REVIEWS:-False}" \
-  -skip-check-review-for-users="${SKIP_CHECK_REVIEWS_FOR_USERS}"
+  -skip-check-review-for-users="${SKIP_CHECK_REVIEWS_FOR_USERS:""}"

--- a/check-pr.sh
+++ b/check-pr.sh
@@ -8,4 +8,4 @@ go run . \
   -github.run-url="$GITHUB_RUN_URL" \
   -skip-check-test-plan="${SKIP_CHECK_TEST_PLAN:-False}" \
   -skip-check-review="${SKIP_CHECK_REVIEWS:-False}" \
-  -skip-check-review-for-users="${SKIP_CHECK_REVIEWS_FOR_USERS:""}"
+  -skip-check-review-for-users="${SKIP_CHECK_REVIEWS_FOR_USERS:-""}"

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 		log.Fatal("Unmarshal: ", err)
 	}
 	log.Printf("handling event for pull request %s, payload: %+v\n", payload.PullRequest.URL, payload.Dump())
+	log.Printf("Full body: %#v", payload)
 
 	// Discard unwanted events
 	switch ref := payload.PullRequest.Base.Ref; ref {

--- a/webhook.go
+++ b/webhook.go
@@ -35,6 +35,8 @@ type PullRequestPayload struct {
 
 	Base RefPayload `json:"base"`
 	Head RefPayload `json:"head"`
+
+	User UserPayload `json:"user"`
 }
 
 type Label struct {


### PR DESCRIPTION
As title. Adds an env var `SKIP_CHECK_REVIEWS_FOR_USERS` which is a CSV list of github handles. If it matches, we can allow a non-reviewed PR.

Also pulls out the review satisfaction checking into it's own little routine and adds an interface so we can actually test the review logic (which was not being done before).

I still need to setup `act` to test that it actually works with some real payloads.